### PR TITLE
Support 2017 and 2018 StackOverflow schemas.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module stackoverflow
+
+go 1.16

--- a/main.go
+++ b/main.go
@@ -12,7 +12,8 @@ import (
 )
 
 func main() {
-	path := "/Users/sameer/Downloads/developer_survey_2019/survey_results_public.csv"
+	path := "data/2020.csv"
+	year := yearFromPath(path)
 	f, err := os.Open(path)
 	if err != nil {
 		log.Fatal(err)
@@ -39,10 +40,11 @@ func main() {
 			continue
 		}
 		keys := make(map[string]keyset)
+		keys["2020"] = keyset{lang: "LanguageWorkedWith", plat: "PlatformWorkedWith", orgSize: "OrgSize"}
 		keys["2019"] = keyset{lang: "LanguageWorkedWith", plat: "PlatformWorkedWith", ed: "DevEnviron", orgSize: "OrgSize"}
 		keys["2018"] = keyset{lang: "LanguageWorkedWith", plat: "PlatformWorkedWith", ed: "IDE", orgSize: "CompanySize"}
 		keys["2017"] = keyset{lang: "HaveWorkedLanguage", plat: "HaveWorkedPlatform", ed: "IDE", orgSize: "CompanySize"}
-		year := yearFromPath(path)
+
 		techSet := make(map[string]bool)
 		addTechs := func(key string) {
 			for _, tech := range strings.Split(rec[schema[key]], ";") {
@@ -52,11 +54,12 @@ func main() {
 		}
 		addTechs(keys[year].lang)
 		addTechs(keys[year].plat)
-		addTechs(keys[year].ed)
+		// addTechs(keys[year].ed)
 		if techSet["AWS"] || techSet["Microsoft Azure"] || techSet["Google Cloud Platform"] || techSet["Amazon Web Services (AWS)"] || techSet["Google Cloud Platform/App Engine"] || techSet["Azure"] {
 			techSet["ANY CLOUD"] = true
 		}
-		if rec[schema[keys[year].orgSize]] == "10,000 or more employees" {
+		orgSize := rec[schema[keys[year].orgSize]]
+		if orgSize == "10,000 or more employees" || orgSize == "1,000 to 4,999 employees" || orgSize == "5,000 to 9,999 employees" {
 			techSet["ANY ENTERPRISE"] = true
 		}
 		if techSet["ANY CLOUD"] && techSet["ANY ENTERPRISE"] {
@@ -123,11 +126,11 @@ type keyset struct {
 }
 
 func yearFromPath(path string) string {
-	// expects the default SO path structure (.../developer_survey_YYYY/survey_results_public.csv)
-	re := regexp.MustCompile(`developer_survey_(\d+)`)
+	// expects files in data/YYYY.csv
+	re := regexp.MustCompile(`data/(\d+)\.csv`)
 	matches := re.FindStringSubmatch(path)
 	if matches == nil {
-		return "2019"
+		return "2020"
 	}
 	return matches[1]
 }

--- a/main.go
+++ b/main.go
@@ -59,6 +59,9 @@ func main() {
 		if rec[schema[keys[year].orgSize]] == "10,000 or more employees" {
 			techSet["ANY ENTERPRISE"] = true
 		}
+		if techSet["ANY CLOUD"] && techSet["ANY ENTERPRISE"] {
+			techSet["ANY CLOUD AND ENTERPRISE"] = true
+		}
 		techSet["ANY"] = true
 		var techs []string
 		for tech := range techSet {

--- a/main.go
+++ b/main.go
@@ -5,13 +5,15 @@ import (
 	"io"
 	"log"
 	"os"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
 )
 
 func main() {
-	f, err := os.Open("/Users/sameer/Downloads/developer_survey_2019/survey_results_public.csv")
+	path := "/Users/sameer/Downloads/developer_survey_2019/survey_results_public.csv"
+	f, err := os.Open(path)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -36,19 +38,25 @@ func main() {
 			}
 			continue
 		}
+		keys := make(map[string]keyset)
+		keys["2019"] = keyset{lang: "LanguageWorkedWith", plat: "PlatformWorkedWith", ed: "DevEnviron", orgSize: "OrgSize"}
+		keys["2018"] = keyset{lang: "LanguageWorkedWith", plat: "PlatformWorkedWith", ed: "IDE", orgSize: "CompanySize"}
+		keys["2017"] = keyset{lang: "HaveWorkedLanguage", plat: "HaveWorkedPlatform", ed: "IDE", orgSize: "CompanySize"}
+		year := yearFromPath(path)
 		techSet := make(map[string]bool)
 		addTechs := func(key string) {
 			for _, tech := range strings.Split(rec[schema[key]], ";") {
+				tech = strings.TrimSpace(tech)
 				techSet[tech] = true
 			}
 		}
-		addTechs("LanguageWorkedWith")
-		addTechs("PlatformWorkedWith")
-		addTechs("DevEnviron")
-		if techSet["AWS"] || techSet["Microsoft Azure"] || techSet["Google Cloud Platform"] {
+		addTechs(keys[year].lang)
+		addTechs(keys[year].plat)
+		addTechs(keys[year].ed)
+		if techSet["AWS"] || techSet["Microsoft Azure"] || techSet["Google Cloud Platform"] || techSet["Amazon Web Services (AWS)"] || techSet["Google Cloud Platform/App Engine"] || techSet["Azure"] {
 			techSet["ANY CLOUD"] = true
 		}
-		if rec[schema["OrgSize"]] == "10,000 or more employees" {
+		if rec[schema[keys[year].orgSize]] == "10,000 or more employees" {
 			techSet["ANY ENTERPRISE"] = true
 		}
 		techSet["ANY"] = true
@@ -102,4 +110,21 @@ func main() {
 		}
 		w.Write(rec)
 	}
+}
+
+type keyset struct {
+	lang    string
+	plat    string
+	ed      string
+	orgSize string
+}
+
+func yearFromPath(path string) string {
+	// expects the default SO path structure (.../developer_survey_YYYY/survey_results_public.csv)
+	re := regexp.MustCompile(`developer_survey_(\d+)`)
+	matches := re.FindStringSubmatch(path)
+	if matches == nil {
+		return "2019"
+	}
+	return matches[1]
 }


### PR DESCRIPTION
Hey Sameer, this patch adds support for the 2017 and 2018 SO schemas. The logic is pretty simple, it looks for the year in the path of the survey data file and uses that to determine which column names to use for languages, platforms, editors, and org sizes.